### PR TITLE
fix(CSN-744) fix set weight process result logging

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1072,8 +1072,8 @@ class Validator:
             weights=weights,  # Weights to set for the miners.
             version_key=__version_as_int__,
             wait_for_inclusion=False,
-        )
-        if isinstance(result[0], bool) and result or isinstance(result, tuple) and result[0]:
+        ) # return type: tuple[bool, str]
+        if isinstance(result, tuple) and result and isinstance(result[0], bool) and result[0]:
             bt.logging.info(result)
             bt.logging.success("✅ Successfully set weights.")
         else:


### PR DESCRIPTION
on set_weights for miner, if the result from bittensor networks is False, previously it would still logged as success.
The new logic will correct that and log the right information.

This can be tested by stop validator and modify code at line 1074, 
from 
```
wait_for_inclusion=False,
```
to
```
wait_for_inclusion=True,
```
then save the change and restart with pm2
```
>>> result=(False,"error message")
>>> bool(isinstance(result, tuple) and result and isinstance(result[0], bool) and result[0])
False
>>> result=tuple()
>>> bool(isinstance(result, tuple) and result and isinstance(result[0], bool) and result[0])
False
>>> result=True
>>> bool(isinstance(result, tuple) and result and isinstance(result[0], bool) and result[0])
False
>>> result=(True,'e')
>>> bool(isinstance(result, tuple) and result and isinstance(result[0], bool) and result[0])
True
```